### PR TITLE
Avoid routing markers in visualization

### DIFF
--- a/src/routing.coffee
+++ b/src/routing.coffee
@@ -1132,7 +1132,7 @@ map.on 'locationfound', (e) ->
         .on 'click', (e) ->
             set_source_marker(point, {accuracy: radius, measure: measure})
 
-map.on 'click', (e) ->
+set_source_or_target_marker = (e) ->
     # don't react to map clicks after both markers have been set
     if sourceMarker? and targetMarker?
         return
@@ -1142,6 +1142,11 @@ map.on 'click', (e) ->
         set_source_marker(e.latlng, {popup: true})
     else if targetMarker == null
         set_target_marker(e.latlng)
+
+map.on 'click', set_source_or_target_marker
+
+# FIXME: Build a nicer interface sometime.
+citynavi.set_source_or_target_marker = set_source_or_target_marker
 
 # Create context menu that allows user to set source and target location as well as add error notes.
 # The menu is shown when the user keeps finger long time on the touchscreen (see contextmenu event

--- a/src/visualization.coffee
+++ b/src/visualization.coffee
@@ -56,6 +56,18 @@ $('#my-routes').bind 'pageinit', (e, data) ->
     $list.empty()
     $list.listview()
 
+$('#my-routes').on 'pageinit', (e, data) ->
+    # FIXME: Make an interface for the map or rename the global variable.
+    map = window.map_dbg
+    # Remove routing functionality.
+    map.off 'click', citynavi.set_source_or_target_marker
+
+$('#my-routes').on 'pagehide', (e, data) ->
+    # FIXME: Make an interface for the map or rename the global variable.
+    map = window.map_dbg
+    # Restore routing functionality.
+    map.on 'click', citynavi.set_source_or_target_marker
+
 $('#my-routes').bind 'pageshow', (e, data) ->
     $list = $('#my-routes ul')
     $list.empty()
@@ -317,6 +329,18 @@ $('#fluency-page').bind 'pagebeforehide', (e, o) ->
     if window.speedLegend?
         window.map_dbg.removeControl window.speedLegend
         window.speedLegend = undefined
+
+$('#fluency-page').on 'pageinit', (e, data) ->
+    # FIXME: Make an interface for the map or rename the global variable.
+    map = window.map_dbg
+    # Remove routing functionality.
+    map.off 'click', citynavi.set_source_or_target_marker
+
+$('#fluency-page').on 'pagehide', (e, data) ->
+    # FIXME: Make an interface for the map or rename the global variable.
+    map = window.map_dbg
+    # Restore routing functionality.
+    map.on 'click', citynavi.set_source_or_target_marker
 
 $(document).bind 'pagebeforechange', (e, data) ->
     console.log "in visualization pagebeforechange"


### PR DESCRIPTION
This should fix #100, for now. jQuery Mobile has deprecated `pagehide` and it will be removed in 1.6.0. We need a modular interface for handling the map, as well.
